### PR TITLE
Makefile: libarduino++.a is gone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,6 @@ BIN = blink.bin blink2.bin test_enc28j60.bin onewire_test.bin test_ip.bin \
 
 all: avr-ports.h .depend $(BIN) $(BIN:.bin=.lst)
 
-$(BIN:.bin=.elf): libarduino++.a
-
 .depend: *.cc *.h
 	$(CC) -mmcu=$(MCU_TARGET) -MM *.cc > .depend
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ LDFLAGS = -Wl,-Map,$@.map $(LIBS)
 BIN = blink.bin blink2.bin test_enc28j60.bin onewire_test.bin test_ip.bin \
       test_serial.bin test_rf12.bin test_nanode_mac.bin
 
-all: avr-ports.h .depend $(BIN) $(BIN:.bin=.lst) libarduino++.a
+all: avr-ports.h .depend $(BIN) $(BIN:.bin=.lst)
 
 $(BIN:.bin=.elf): libarduino++.a
 


### PR DESCRIPTION
This was probably another merge bug.
